### PR TITLE
Fix incorrect notation in documentation

### DIFF
--- a/tasks/ReplaceTokensV6/README.md
+++ b/tasks/ReplaceTokensV6/README.md
@@ -235,7 +235,7 @@ If you are migrating from **v3 to v6** make sure to read this documentation firs
     #   - custom: token-prefix ... token-suffix
     #   - doublebraces: {{ ... }}
     #   - doubleunderscores: __ ... __
-    #   - githubactions: #{{ ... }}
+    #   - githubactions: ${{ ... }}
     #   - octopus: #{ ... }
     #
     # Optional. Default: default


### PR DESCRIPTION
In V6 of the task, the list of accepted values for the input paramter 'tokenPattern' has been extended to include 'githubactions'. The documentation states that 'githubactions' will replace tokens enclosed in `#{{ ... }}`, but according to the documentation of [qetza/replacetokens](https://github.com/qetza/replacetokens/blob/main/README.md), which this task is using to do the actual token replacement, the token should be enclosed in `${{ ... }}`, i.e. the leading hashtag should be a dollar sign.